### PR TITLE
Fixing Meson GLib build.

### DIFF
--- a/src/glib.mk
+++ b/src/glib.mk
@@ -56,7 +56,7 @@ define $(PKG)_BUILD_NATIVE
     --prefix '$(PREFIX)' \
     build
 
-    cd '$(SOURCE_DIR)/build' && meson compile && meson install
+    cd '$(SOURCE_DIR)/build' && ninja && meson install
 endef
 
 define $(PKG)_BUILD_$(BUILD)
@@ -78,5 +78,5 @@ define $(PKG)_BUILD
     --prefix '$(PREFIX)/armv7-w64-mingw32' \
     build-arm
 
-    cd '$(SOURCE_DIR)/build-arm' && meson compile && meson install
+    cd '$(SOURCE_DIR)/build-arm' && ninja && meson install
 endef


### PR DESCRIPTION
Meson 0.53.2 (a relatively new build from Ubuntu 20.04 LTS distro)
does not have a "meson compile" flag. As a result, "meson compile"
is interpreted as if "compile" were a build directory name.

The Meson man page suggests calling the build system directly, e.g.
`ninja`.