### PR TITLE
Disable the OpenMP test on ARM targets as OpenMP build needs UASM.

### DIFF
--- a/src/pthreads.mk
+++ b/src/pthreads.mk
@@ -24,10 +24,12 @@ define $(PKG)_BUILD
         '$(TOP_DIR)/src/$(PKG)-test.c' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
         `'$(TARGET)-pkg-config' --libs pthreads`
 
-    '$(TARGET)-gcc' \
-        -W -Wall -Werror -ansi -pedantic \
-        '$(TOP_DIR)/src/$(PKG)-libgomp-test.c' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG)-libgomp.exe' \
-        -fopenmp
+    $(if $(BUILD_NATIVE), \
+        '$(TARGET)-gcc' \
+            -W -Wall -Werror -ansi -pedantic \
+            '$(TOP_DIR)/src/$(PKG)-libgomp-test.c' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG)-libgomp.exe' \
+            -fopenmp \
+    )
 
     # test cmake
     mkdir '$(1).test-cmake'


### PR DESCRIPTION
As far as I understand, UASM, the OpenMP prerequisite, only supports Intel. OMP builds are disabled for ARM*.
Therefore the unit test that depends on OpenMP needs to be conditionally turned off.
This fixes building pthreads.
Feel free to reject if this temporary fix is not enough and the root case issue (OMP on ARM) should be addressed instead.